### PR TITLE
Minor changes to make code deployable on latest Cloudflare workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ http://www.zibri.org/2019/07/your-own-cors-anywhere-proxy-on.html
 This project is written in [Cloudfalre Workers](https://workers.cloudflare.com/), and can be easily deployed with [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/).
 
 ```bash
-wrangler publish
+wrangler deploy
 ```
 
 ## Usage Example

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ addEventListener("fetch", async event => {
                 });
 
                 const response = await fetch(targetUrl, newRequest);
-                const responseHeaders = new Headers(response.headers);
+                let responseHeaders = new Headers(response.headers);
                 const exposedHeaders = [];
                 const allResponseHeaders = {};
                 for (const [key, value] of response.headers.entries()) {
@@ -118,7 +118,7 @@ addEventListener("fetch", async event => {
                 return new Response(responseBody, responseInit);
 
             } else {
-                const responseHeaders = new Headers();
+                let responseHeaders = new Headers();
                 responseHeaders = setupCORSHeaders(responseHeaders);
 
                 let country = false;


### PR DESCRIPTION
Fixes:

- [ERROR] Cannot assign to "responseHeaders" because it is a constant
- [WARNING] `wrangler publish` is deprecated and will be removed in the next major version.